### PR TITLE
Update bufferLength once instead of twice per channel

### DIFF
--- a/src/AudioRecorder.js
+++ b/src/AudioRecorder.js
@@ -36,8 +36,8 @@ class AudioRecorder extends Component {
         for(let i = 0; i < 2; i++) {
           const channel = event.inputBuffer.getChannelData(i);
           this.buffers[i].push(new Float32Array(channel));
-          this.bufferLength += bufferSize;
         }
+        this.bufferLength += bufferSize;
       };
 
       gain.connect(recorder);


### PR DESCRIPTION
Hello!

I came upon this project and adapted it for something else I'm working on, and ran into a bug where the encoded WAV file would be twice the length I expected.  I changed this in my adaptation to address, and figured there might be a similar issue upstream here.

Thanks for your work here and for sharing!