### PR TITLE
Bug / Issue When Remove Already Recorded Audio

### DIFF
--- a/src/AudioRecorder.js
+++ b/src/AudioRecorder.js
@@ -117,6 +117,8 @@ class AudioRecorder extends Component {
       if(this.playbackSource) {
         this.playbackSource.stop();
         delete this.playbackSource;
+        this.buffers = [[], []];
+        this.bufferLength = 0;
       }
 
       this.setState({


### PR DESCRIPTION
Issue described here: https://github.com/danrouse/react-audio-recorder/issues/9

I managed to fix one part of the issue - when an audio is removed and then a new audio is recorded --> when you `startPlayback` (play) - the new audio plays!

However, the new audio plays on slow motion still. I can't understand why is that :(

@danrouse , could you please help me so we solve the last part of the issue?