### PR TITLE
expect navigator.mediaDevices.getUserMedia to return a Promise

### DIFF
--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -1,7 +1,15 @@
-export default navigator.mediaDevices ?
-  navigator.mediaDevices.getUserMedia :
-  (
+let getUserMedia;
+
+if (navigator.mediaDevices) {
+  getUserMedia = (arg, successCallback, errorCallback) => {
+    navigator.mediaDevices.getUserMedia(arg).then(successCallback).catch(errorCallback);
+  };
+} else {
+  getUserMedia = (
     navigator.getUserMedia ||
     navigator.webkitGetUserMedia ||
     navigator.mozGetUserMedia
   );
+}
+
+export default getUserMedia;


### PR DESCRIPTION
This fixes https://github.com/danrouse/react-audio-recorder/issues/26

Thanks to @toneplex for pointing out that `navigator.mediaDevices.getUserMedia` returns a promise rather than accepting callback args